### PR TITLE
Trim precision to 4 on shelter coordinates so rescued update occurs a…

### DIFF
--- a/src/main/java/com/redhat/emergency/response/disaster/RestApiVerticle.java
+++ b/src/main/java/com/redhat/emergency/response/disaster/RestApiVerticle.java
@@ -118,7 +118,7 @@ public class RestApiVerticle extends CacheAccessVerticle {
      */
     private boolean applyDisasterJson(JsonObject json) {
         try {
-            Json.decodeValue(json.getJsonArray("shelters").encode(), Shelter[].class);
+            json.put("shelters", Json.encode(Json.decodeValue(json.getJsonArray("shelters").encode(), Shelter[].class)));
             Json.decodeValue(json.getJsonArray("inclusionZones").encode(), InclusionZone[].class);
             Json.decodeValue(json.getJsonObject("center").encode(), DisasterCenter.class);
         } catch (Exception e) {

--- a/src/main/java/com/redhat/emergency/response/disaster/RestApiVerticle.java
+++ b/src/main/java/com/redhat/emergency/response/disaster/RestApiVerticle.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 
 import io.vertx.core.Future;
 import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.oauth2.OAuth2Auth;
 import io.vertx.ext.auth.oauth2.OAuth2FlowType;
@@ -118,7 +119,7 @@ public class RestApiVerticle extends CacheAccessVerticle {
      */
     private boolean applyDisasterJson(JsonObject json) {
         try {
-            json.put("shelters", Json.encode(Json.decodeValue(json.getJsonArray("shelters").encode(), Shelter[].class)));
+            json.put("shelters", new JsonArray(Json.encode(Json.decodeValue(json.getJsonArray("shelters").encode(), Shelter[].class))));
             Json.decodeValue(json.getJsonArray("inclusionZones").encode(), InclusionZone[].class);
             Json.decodeValue(json.getJsonObject("center").encode(), DisasterCenter.class);
         } catch (Exception e) {

--- a/src/main/java/com/redhat/emergency/response/disaster/model/Shelter.java
+++ b/src/main/java/com/redhat/emergency/response/disaster/model/Shelter.java
@@ -2,11 +2,22 @@ package com.redhat.emergency.response.disaster.model;
 
 import java.math.BigDecimal;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.redhat.emergency.response.disaster.util.DoubleContextualSerializer;
+import com.redhat.emergency.response.disaster.util.Precision;
+
 public class Shelter {
     private String id;
     private String name;
+
+    @JsonSerialize(using = DoubleContextualSerializer.class)
+    @Precision(precision = 4)
     private BigDecimal lon;
+    
+    @JsonSerialize(using = DoubleContextualSerializer.class)
+    @Precision(precision = 4)
     private BigDecimal lat;
+    
     private int rescued;
 
     public Shelter() {   

--- a/src/main/java/com/redhat/emergency/response/disaster/model/Shelter.java
+++ b/src/main/java/com/redhat/emergency/response/disaster/model/Shelter.java
@@ -12,18 +12,18 @@ public class Shelter {
 
     @JsonSerialize(using = DoubleContextualSerializer.class)
     @Precision(precision = 4)
-    private BigDecimal lon;
+    private double lon;
     
     @JsonSerialize(using = DoubleContextualSerializer.class)
     @Precision(precision = 4)
-    private BigDecimal lat;
+    private double lat;
     
     private int rescued;
 
     public Shelter() {   
     }
 
-    public Shelter(String id, String name, BigDecimal lon, BigDecimal lat, int rescued) {
+    public Shelter(String id, String name, double lon, double lat, int rescued) {
         this.id = id;
         this.name = name;
         this.lon = lon;
@@ -47,19 +47,19 @@ public class Shelter {
         this.name = name;
     }
 
-    public BigDecimal getLon() {
+    public double getLon() {
         return this.lon;
     }
 
-    public void setLon(BigDecimal lon) {
+    public void setLon(double lon) {
         this.lon = lon;
     }
 
-    public BigDecimal getLat() {
+    public double getLat() {
         return this.lat;
     }
 
-    public void setLat(BigDecimal lat) {
+    public void setLat(double lat) {
         this.lat = lat;
     }
 
@@ -81,12 +81,12 @@ public class Shelter {
         return this;
     }
 
-    public Shelter lon(BigDecimal lon) {
+    public Shelter lon(double lon) {
         this.lon = lon;
         return this;
     }
 
-    public Shelter lat(BigDecimal lat) {
+    public Shelter lat(double lat) {
         this.lat = lat;
         return this;
     }

--- a/src/main/java/com/redhat/emergency/response/disaster/util/DoubleContextualSerializer.java
+++ b/src/main/java/com/redhat/emergency/response/disaster/util/DoubleContextualSerializer.java
@@ -1,0 +1,46 @@
+package com.redhat.emergency.response.disaster.util;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.ContextualSerializer;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public class DoubleContextualSerializer extends JsonSerializer<Double> implements ContextualSerializer {
+
+    private int precision = 0;
+
+    public DoubleContextualSerializer (int precision) {
+        this.precision = precision;
+    }
+
+    public DoubleContextualSerializer () {
+
+    }
+
+    @Override
+    public void serialize(Double value, JsonGenerator gen, SerializerProvider serializers) throws IOException, JsonProcessingException {
+        if (precision == 0) {
+            gen.writeNumber(value.doubleValue());
+        } else {
+            BigDecimal bd = new BigDecimal(value);
+            bd = bd.setScale(precision, RoundingMode.HALF_UP);
+            gen.writeNumber(bd.doubleValue());
+        }
+
+    }
+    @Override
+    public JsonSerializer<?> createContextual(SerializerProvider prov, BeanProperty property) throws JsonMappingException {
+        Precision precision = property.getAnnotation(Precision.class);
+        if (precision != null) {
+            return new DoubleContextualSerializer (precision.precision());
+        }
+        return this;
+    }
+}

--- a/src/main/java/com/redhat/emergency/response/disaster/util/Precision.java
+++ b/src/main/java/com/redhat/emergency/response/disaster/util/Precision.java
@@ -1,0 +1,12 @@
+package com.redhat.emergency.response.disaster.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD,ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Precision {
+    int precision();
+}

--- a/src/main/resources/new-york.json
+++ b/src/main/resources/new-york.json
@@ -8,20 +8,20 @@
     "shelters" : [ {
       "id" : "464f7940-4e5d-11ea-bcc5-c73f08b10245",
       "name" : "Jersey City Emergency Center",
-      "lon" : -74.09324756959484,
-      "lat" : 40.7406145325902,
+      "lon" : -74.0932,
+      "lat" : 40.7406,
       "rescued" : 0
     }, {
       "id" : "5a3b6b30-4e5d-11ea-b3fa-c56d7a8032b3",
       "name" : "JFK Emergency Shelter",
-      "lon" : -73.83223105800536,
-      "lat" : 40.65551467848243,
+      "lon" : -73.8322,
+      "lat" : 40.6555,
       "rescued" : 0
     }, {
       "id" : "7aab6780-4e5d-11ea-b3fa-c56d7a8032b3",
       "name" : "Staten Island Critical Care",
-      "lon" : -74.18144972524011,
-      "lat" : 40.63842282457446,
+      "lon" : -74.1814,
+      "lat" : 40.6384,
       "rescued" : 0
     } ],
     "inclusionZones" : [ {


### PR DESCRIPTION
…s expected

Borrowed these classes from the mission-service. Because the mission service rounds a mission's destination latitude and longitude to 4, this code in the emergency-console was failing if a newly-placed shelter produced a more precise decimal (it was ~10):

```java
private handleMissionComplete(mission: Mission): void {
    if (mission.status !== 'COMPLETED') {
      return;
    }
    this.shelters = this.shelters.map(s => {
      if (mission.destinationLat === s.lat && mission.destinationLong === s.lon) {
        s.rescued++;
      }
      return s;
    });
  }
```